### PR TITLE
fix(blocks): fix an issue with block registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/SoSly/ArcaneAdditions/tree/1.20.1)
+### Fixed
+- the game no longer crashes with MnA 3.0.0.17
+
 ## [1.20.1-forge-1.9.4](https://github.com/SoSly/ArcaneAdditions/releases/tag/1.20.1-forge-1.9.4)
 ### Added
 - chinese localization (thanks to @xiaoknya).

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,7 +43,7 @@ curios_fileId = 5086821
 geckolib_projectId = 388172
 geckolib_fileId = 5060416
 mna_projectId = 406360
-mna_fileId = 5308897
+mna_fileId = 5511388
 mna_version_range = [3.0.0.14,4)
 
 ####################

--- a/src/main/java/org/sosly/arcaneadditions/blocks/BlockRegistry.java
+++ b/src/main/java/org/sosly/arcaneadditions/blocks/BlockRegistry.java
@@ -4,7 +4,7 @@ import com.mna.api.blocks.interfaces.ICutoutBlock;
 import com.mna.api.blocks.interfaces.ITranslucentBlock;
 import com.mna.api.items.MACreativeTabs;
 import com.mna.api.items.TieredBlockItem;
-import com.mna.blocks.IOffsetPlace;
+import com.mna.api.blocks.interfaces.IOffsetPlace;
 import com.mna.items.OffsetPlacerItem;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;

--- a/src/main/java/org/sosly/arcaneadditions/gui/menus/ScribesBenchMenu.java
+++ b/src/main/java/org/sosly/arcaneadditions/gui/menus/ScribesBenchMenu.java
@@ -2,7 +2,7 @@ package org.sosly.arcaneadditions.gui.menus;
 
 import com.mna.gui.containers.block.SimpleWizardLabContainer;
 import com.mna.gui.containers.slots.ItemFilterSlot;
-import com.mna.gui.containers.slots.SingleItemSlot;
+import com.mna.api.gui.SingleItemSlot;
 import com.mna.items.ItemInit;
 import com.mna.items.filters.SpellItemFilter;
 import net.minecraft.network.FriendlyByteBuf;


### PR DESCRIPTION
This was caused by MnA moving two interfaces that
were previously only available deep in the code
out to the API.  We have now updated to use the API version of these interfaces where needed.

Resolves #100.