### PR TITLE
Fix casting resource type changes for familiars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/SoSly/ArcaneAdditions/tree/1.20.1
+## [Unreleased](https://github.com/SoSly/ArcaneAdditions/tree/1.20.1)
 
 ### Fixed
 - Added a loot table to the scribe's bench so that it properly drops when broken
 - Fixed a typo in the Soul Searcher's Lens guidebook description
+- Fixed a bug preventing familiars from changing casting resource types
 
 ## [1.20.1-forge-1.9.6](https://github.com/SoSly/ArcaneAdditions/releases/tag/1.20.1-forge-1.9.6)
 ### Changed

--- a/src/main/java/org/sosly/arcaneadditions/capabilities/familiar/FamiliarCapability.java
+++ b/src/main/java/org/sosly/arcaneadditions/capabilities/familiar/FamiliarCapability.java
@@ -79,19 +79,28 @@ public class FamiliarCapability implements IFamiliarCapability {
 
     @Override
     public void setCastingResourceType(ResourceLocation resourceLocation) {
-        if (resourceLocation != null && resourceLocation.getPath().isEmpty() && !this.getCastingResource().getRegistryName().equals(resourceLocation)) {
-            Class<? extends ICastingResource> resource = CastingResourceRegistry.Instance.getRegisteredClass(resourceLocation);
-            float amount = (this.castingResource.getAmount() != 0 ? this.castingResource.getAmount() : 0);
+        if (resourceLocation == null) {
+            return;
+        }
+        
+        if (resourceLocation.getPath().isEmpty()) {
+            return;
+        }
+        
+        if (this.getCastingResource().getRegistryName().equals(resourceLocation)) {
+            return;
+        }
+        
+        Class<? extends ICastingResource> resource = CastingResourceRegistry.Instance.getRegisteredClass(resourceLocation);
+        float amount = this.castingResource.getAmount();
 
-            try {
-                this.castingResource = resource.getConstructor().newInstance();
-                this.castingResource.setMaxAmountByLevel(this.getMagicLevel());
-                this.castingResource.setAmount(amount);
-            } catch (Exception err) {
-                ArcaneAdditions.LOGGER.error("Failed to set casting resource type from identifier " + resourceLocation);
-                ArcaneAdditions.LOGGER.error(err);
-            }
-
+        try {
+            this.castingResource = resource.getConstructor().newInstance();
+            this.castingResource.setMaxAmountByLevel(this.getMagicLevel());
+            this.castingResource.setAmount(amount);
+        } catch (Exception err) {
+            ArcaneAdditions.LOGGER.error("Failed to set casting resource type from identifier " + resourceLocation);
+            ArcaneAdditions.LOGGER.error(err);
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixed a bug that prevented familiars from changing casting resource types
- Refactored method for better code clarity

## Details
The condition check in `setCastingResourceType()` was broken, making the entire resource type change logic unreachable. This PR fixes the validation logic and refactors the method to use early returns for cleaner code flow.

Fixes #121

## Test plan
- [ ] Verify familiars can change casting resource types
- [ ] Confirm invalid resource locations are properly rejected
- [ ] Test that redundant resource type changes are ignored

🤖 Generated with [Claude Code](https://claude.ai/code)