### PR TITLE
Centralize remaining magic numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Familiar AI behavior settings to server config for movement, spellcasting, and wandering
+- Familiar healing rate and interval settings to server config
 
 ### Fixed
 - Added a loot table to the scribe's bench so that it properly drops when broken

--- a/src/main/java/org/sosly/arcaneadditions/capabilities/familiar/FamiliarCapability.java
+++ b/src/main/java/org/sosly/arcaneadditions/capabilities/familiar/FamiliarCapability.java
@@ -26,6 +26,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import org.sosly.arcaneadditions.ArcaneAdditions;
 import org.sosly.arcaneadditions.spells.FamiliarSpell;
+import org.sosly.arcaneadditions.config.ServerConfig;
+import org.sosly.arcaneadditions.entities.ai.config.FamiliarAIConfig;
 import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
 import java.util.Collection;
@@ -34,7 +36,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class FamiliarCapability implements IFamiliarCapability {
-    private static final float FAMILIAR_HEALING_RATE = 25.0f;
 
 
     private boolean bapped = false;
@@ -280,7 +281,7 @@ public class FamiliarCapability implements IFamiliarCapability {
         lastHealingTick = lastHealingTick > 0 ? lastHealingTick : caster.level().getGameTime();
         lastMaintenanceTick = lastMaintenanceTick > 0 ? lastMaintenanceTick : caster.level().getGameTime();
 
-        if (lastMaintenanceTick < (caster.level().getGameTime() - 40L)) {
+        if (lastMaintenanceTick < (caster.level().getGameTime() - FamiliarAIConfig.MAINTENANCE_TICK_INTERVAL)) {
             // check whether the familiar's max mana needs to be updated based on the caster's magic level
             castingResource.setMaxAmountByLevel(this.getMagicLevel());
             lastMaintenanceTick = caster.level().getGameTime();
@@ -307,19 +308,19 @@ public class FamiliarCapability implements IFamiliarCapability {
         }
 
         // regenerate the familiar's health at the cost of mana
-        if (familiar.getHealth() < familiar.getMaxHealth() && lastHealingTick < (caster.level().getGameTime() - 20L)) {
-            int toRestore = (int) (caster.level().getGameTime() - lastHealingTick) / 20;
+        if (familiar.getHealth() < familiar.getMaxHealth() && lastHealingTick < (caster.level().getGameTime() - ServerConfig.familiarHealingTickInterval)) {
+            int toRestore = (int) (caster.level().getGameTime() - lastHealingTick) / ServerConfig.familiarHealingTickInterval;
             while (toRestore > 0) {
-                if (familiar.getHealth() >= familiar.getMaxHealth() || castingResource.getAmount() < FAMILIAR_HEALING_RATE) {
+                if (familiar.getHealth() >= familiar.getMaxHealth() || castingResource.getAmount() < ServerConfig.familiarHealingRate) {
                     // no healing needed or not enough mana
                     break;
                 }
                 familiar.heal(1);
-                castingResource.consume(familiar, FAMILIAR_HEALING_RATE);
+                castingResource.consume(familiar, (float)ServerConfig.familiarHealingRate);
                 toRestore--;
             }
             lastHealingTick = caster.level().getGameTime();
-        } else if (lastHealingTick < (caster.level().getGameTime() - 20L)) {
+        } else if (lastHealingTick < (caster.level().getGameTime() - ServerConfig.familiarHealingTickInterval)) {
             lastHealingTick = caster.level().getGameTime();
         }
     }
@@ -336,6 +337,6 @@ public class FamiliarCapability implements IFamiliarCapability {
 
     private int getMagicLevel() {
         IPlayerMagic magic = caster.getCapability(PlayerMagicProvider.MAGIC).orElse(null);
-        return magic.getMagicLevel() / 5; // todo: configure?
+        return magic.getMagicLevel() / FamiliarAIConfig.MAGIC_LEVEL_DIVISOR;
     }
 }

--- a/src/main/java/org/sosly/arcaneadditions/config/ServerConfig.java
+++ b/src/main/java/org/sosly/arcaneadditions/config/ServerConfig.java
@@ -193,6 +193,17 @@ public class ServerConfig {
             .translation("config.arcaneadditions.wander_max_attempts")
             .defineInRange("wanderMaxAttempts", 10, 1, 50);
 
+    // Familiar Healing
+    private static final ForgeConfigSpec.DoubleValue FAMILIAR_HEALING_RATE = BUILDER
+            .comment("Mana cost per health point when familiar heals")
+            .translation("config.arcaneadditions.familiar_healing_rate")
+            .defineInRange("familiarHealingRate", 25.0, 1.0, 100.0);
+
+    private static final ForgeConfigSpec.IntValue FAMILIAR_HEALING_TICK_INTERVAL = BUILDER
+            .comment("Ticks between familiar healing attempts")
+            .translation("config.arcaneadditions.familiar_healing_tick_interval")
+            .defineInRange("familiarHealingTickInterval", 20, 1, 200);
+
     static {
         BUILDER.pop();
     }
@@ -227,6 +238,8 @@ public class ServerConfig {
     public static int wanderSearchRadius;
     public static int wanderSearchHeight;
     public static int wanderMaxAttempts;
+    public static double familiarHealingRate;
+    public static int familiarHealingTickInterval;
 
     @SubscribeEvent
     static void onLoad(final ModConfigEvent event) {
@@ -257,6 +270,8 @@ public class ServerConfig {
         wanderSearchRadius = WANDER_SEARCH_RADIUS.get();
         wanderSearchHeight = WANDER_SEARCH_HEIGHT.get();
         wanderMaxAttempts = WANDER_MAX_ATTEMPTS.get();
+        familiarHealingRate = FAMILIAR_HEALING_RATE.get();
+        familiarHealingTickInterval = FAMILIAR_HEALING_TICK_INTERVAL.get();
     }
 
     public static <T> boolean isValidEntityList(T entry) {

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/config/FamiliarAIConfig.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/config/FamiliarAIConfig.java
@@ -22,4 +22,12 @@ public final class FamiliarAIConfig {
     
     public static final double WANDER_VERTICAL_OFFSET = 0.0D;
     public static final float WANDER_PATH_COST_THRESHOLD = 0.0F;
+    
+    public static final float CAST_DISTANCE_SQUARED = 256.0F;
+    
+    public static final int MAGIC_LEVEL_DIVISOR = 5;
+    
+    public static final long MAINTENANCE_TICK_INTERVAL = 40L;
+    
+    public static final int TRANSFUSE_EFFICIENCY_DIVISOR = 5;
 }

--- a/src/main/java/org/sosly/arcaneadditions/spells/components/TransfuseComponent.java
+++ b/src/main/java/org/sosly/arcaneadditions/spells/components/TransfuseComponent.java
@@ -25,6 +25,7 @@ import com.mna.factions.Factions;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.LivingEntity;
+import org.sosly.arcaneadditions.entities.ai.config.FamiliarAIConfig;
 
 public class TransfuseComponent extends SpellEffect implements IDamageComponent {
     public TransfuseComponent(ResourceLocation guiIcon) {
@@ -39,7 +40,7 @@ public class TransfuseComponent extends SpellEffect implements IDamageComponent 
         LivingEntity livingSource = null;
         float damage = mods.getValue(Attribute.DAMAGE) * GeneralConfig.getDamageMultiplier();
         float magnitude = mods.getValue(Attribute.MAGNITUDE);
-        float healing = damage * (magnitude / 5);
+        float healing = damage * (magnitude / FamiliarAIConfig.TRANSFUSE_EFFICIENCY_DIVISOR);
 
         if (target.isLivingEntity() && target.getLivingEntity() != null) {
             livingTarget = target.getLivingEntity();

--- a/src/main/java/org/sosly/arcaneadditions/utils/FamiliarHelper.java
+++ b/src/main/java/org/sosly/arcaneadditions/utils/FamiliarHelper.java
@@ -14,6 +14,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import org.sosly.arcaneadditions.capabilities.familiar.FamiliarProvider;
 import org.sosly.arcaneadditions.capabilities.familiar.IFamiliarCapability;
 import org.sosly.arcaneadditions.entities.ai.*;
+import org.sosly.arcaneadditions.entities.ai.config.FamiliarAIConfig;
 
 public class FamiliarHelper {
     private static final String CASTER = "arcaneadditions:familiar/caster";
@@ -50,7 +51,7 @@ public class FamiliarHelper {
         cap.setFamiliar(familiar);
         cap.setType(type);
         cap.setName(name.getString());
-        cap.getCastingResource().setMaxAmountByLevel(magic.getMagicLevel() / 5); // todo: this should be a configuration variable
+        cap.getCastingResource().setMaxAmountByLevel(magic.getMagicLevel() / FamiliarAIConfig.MAGIC_LEVEL_DIVISOR);
         if (cap.getCastingResource().getMaxAmount() < cap.getCastingResource().getAmount()) {
             cap.getCastingResource().setAmount(cap.getCastingResource().getMaxAmount());
         }
@@ -161,9 +162,9 @@ public class FamiliarHelper {
 
         // Add new goals
         familiar.goalSelector.addGoal(2, new StayWhenOrderedToGoal(familiar));
-        familiar.goalSelector.addGoal(5, new CastOffensiveSpell(familiar, 16.0F * 16.0F));
+        familiar.goalSelector.addGoal(5, new CastOffensiveSpell(familiar, FamiliarAIConfig.CAST_DISTANCE_SQUARED));
         familiar.goalSelector.addGoal(6, new FollowCasterGoal(familiar, 1.0D, 20, 2.0F, 16, false));
-        familiar.goalSelector.addGoal(7, new CastUtilitySpell(familiar, 16.0F * 16.0F));
+        familiar.goalSelector.addGoal(7, new CastUtilitySpell(familiar, FamiliarAIConfig.CAST_DISTANCE_SQUARED));
         familiar.goalSelector.addGoal(10, new RandomWanderGoal(familiar, 1.0D, 20));
 
         familiar.targetSelector.addGoal(0, new NeverTargetCasterGoal(familiar));


### PR DESCRIPTION
Completes extraction of magic numbers into configuration values and constants.

## Changes
- Added configurable healing rate and interval settings for familiars to ServerConfig
- Added constants to FamiliarAIConfig for cast distance, magic level divisor, maintenance interval, and transfuse efficiency
- Updated FamiliarCapability, FamiliarHelper, and TransfuseComponent to use constants instead of hardcoded values

## Related Issues
Closes #124

## Implementation Notes
Healing values are user-configurable through ServerConfig since they affect gameplay balance. Other values are implementation constants in FamiliarAIConfig since they're technical values that shouldn't change.

## Breaking Changes
None

🤖 Generated with [Claude Code](https://claude.ai/code)