### PR TITLE
Fix AI goal consistency for familiar spellcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/SoSly/ArcaneAdditions/tree/1.20.1)
 
 ### Added
-- Added familiar AI behavior settings to server config
+- Added familiar AI behavior settings to the server config
+
+### Changed
+- Improved familiar spellcasting reliability; familiars will now more consistently cast offensive and utility spells when appropriate
+- Familiars now better respect their spell cooldowns when deciding whether to cast
 
 ### Fixed
 - Added a loot table to the scribe's bench so that it properly drops when broken
 - Fixed a typo in the Soul Searcher's Lens guidebook description
 - Fixed a bug preventing familiars from changing casting resource types
 - Improved familiar tracking performance when crossing dimensions or exploring distant areas
+- Fixed familiars attempting to cast spells they couldn't afford or were still on cooldown
+- Fixed familiars continuing to try casting spells after their target was defeated
 
 ## [1.20.1-forge-1.9.6](https://github.com/SoSly/ArcaneAdditions/releases/tag/1.20.1-forge-1.9.6)
 ### Changed

--- a/src/main/java/org/sosly/arcaneadditions/capabilities/familiar/FamiliarCapability.java
+++ b/src/main/java/org/sosly/arcaneadditions/capabilities/familiar/FamiliarCapability.java
@@ -27,7 +27,7 @@ import net.minecraft.world.level.Level;
 import org.sosly.arcaneadditions.ArcaneAdditions;
 import org.sosly.arcaneadditions.spells.FamiliarSpell;
 import org.sosly.arcaneadditions.config.ServerConfig;
-import org.sosly.arcaneadditions.entities.ai.config.FamiliarAIConfig;
+import org.sosly.arcaneadditions.entities.ai.Constants;
 import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
 import java.util.Collection;
@@ -85,15 +85,15 @@ public class FamiliarCapability implements IFamiliarCapability {
         if (resourceLocation == null) {
             return;
         }
-        
+
         if (resourceLocation.getPath().isEmpty()) {
             return;
         }
-        
+
         if (this.getCastingResource().getRegistryName().equals(resourceLocation)) {
             return;
         }
-        
+
         Class<? extends ICastingResource> resource = CastingResourceRegistry.Instance.getRegisteredClass(resourceLocation);
         float amount = this.castingResource.getAmount();
 
@@ -121,7 +121,7 @@ public class FamiliarCapability implements IFamiliarCapability {
         if (server == null) {
             return null;
         }
-        
+
         if (lastKnownDimension != null) {
             Mob found = searchDimension(server.getLevel(lastKnownDimension));
             if (found != null) {
@@ -134,12 +134,12 @@ public class FamiliarCapability implements IFamiliarCapability {
             if (lastKnownDimension != null && level.dimension().equals(lastKnownDimension)) {
                 continue;
             }
-            
+
             Mob found = searchDimension(level);
             if (found == null) {
                 continue;
             }
-            
+
             familiar = found;
             lastKnownDimension = level.dimension();
             return familiar;
@@ -154,12 +154,12 @@ public class FamiliarCapability implements IFamiliarCapability {
         if (level == null) {
             return null;
         }
-        
+
         Mob entity = (Mob) level.getEntity(familiarUUID);
         if (entity == null || entity.isRemoved()) {
             return null;
         }
-        
+
         return entity;
     }
 
@@ -281,7 +281,7 @@ public class FamiliarCapability implements IFamiliarCapability {
         lastHealingTick = lastHealingTick > 0 ? lastHealingTick : caster.level().getGameTime();
         lastMaintenanceTick = lastMaintenanceTick > 0 ? lastMaintenanceTick : caster.level().getGameTime();
 
-        if (lastMaintenanceTick < (caster.level().getGameTime() - FamiliarAIConfig.MAINTENANCE_TICK_INTERVAL)) {
+        if (lastMaintenanceTick < (caster.level().getGameTime() - Constants.MAINTENANCE_TICK_INTERVAL)) {
             // check whether the familiar's max mana needs to be updated based on the caster's magic level
             castingResource.setMaxAmountByLevel(this.getMagicLevel());
             lastMaintenanceTick = caster.level().getGameTime();
@@ -337,6 +337,6 @@ public class FamiliarCapability implements IFamiliarCapability {
 
     private int getMagicLevel() {
         IPlayerMagic magic = caster.getCapability(PlayerMagicProvider.MAGIC).orElse(null);
-        return magic.getMagicLevel() / FamiliarAIConfig.MAGIC_LEVEL_DIVISOR;
+        return magic.getMagicLevel() / Constants.MAGIC_LEVEL_DIVISOR;
     }
 }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/AbstractFamiliarTargetGoal.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/AbstractFamiliarTargetGoal.java
@@ -1,55 +1,56 @@
 package org.sosly.arcaneadditions.entities.ai;
 
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.player.Player;
 import org.sosly.arcaneadditions.capabilities.familiar.IFamiliarCapability;
 import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
 import javax.annotation.Nullable;
 
-public abstract class AbstractFamiliarGoal extends Goal {
-    protected final Mob familiar;
+public abstract class AbstractFamiliarTargetGoal extends TargetGoal {
     protected final IFamiliarCapability capability;
-
-    protected AbstractFamiliarGoal(Mob familiar) {
-        this.familiar = familiar;
+    
+    protected AbstractFamiliarTargetGoal(Mob familiar, boolean mustSee) {
+        super(familiar, mustSee);
         this.capability = FamiliarHelper.getFamiliarCapability(familiar);
     }
-
+    
+    protected AbstractFamiliarTargetGoal(Mob familiar, boolean mustSee, boolean mustReach) {
+        super(familiar, mustSee, mustReach);
+        this.capability = FamiliarHelper.getFamiliarCapability(familiar);
+    }
+    
     @Override
     public void start() {
         super.start();
-        System.out.println("[DEBUG] Starting goal: " + this.getClass().getSimpleName());
+        System.out.println("[DEBUG] Starting target goal: " + this.getClass().getSimpleName());
     }
-
+    
     @Override
     public void stop() {
         super.stop();
-
-        if (!this.getClass().getSimpleName().equals("RandomWanderGoal")) {
-            System.out.println("[DEBUG] Stopping goal: " + this.getClass().getSimpleName());
-        }
+        System.out.println("[DEBUG] Stopping target goal: " + this.getClass().getSimpleName());
     }
-
+    
     @Nullable
     protected IFamiliarCapability getFamiliarCapability() {
         return capability;
     }
-
+    
     protected boolean hasValidCapability() {
         return capability != null;
     }
-
+    
     @Nullable
     protected Player getCaster() {
         return capability != null ? capability.getCaster() : null;
     }
-
+    
     protected boolean isOrderedToStay() {
         return capability != null && capability.isOrderedToStay();
     }
-
+    
     protected boolean isBapped() {
         return capability != null && capability.isBapped();
     }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/CastOffensiveSpell.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/CastOffensiveSpell.java
@@ -5,18 +5,15 @@ import com.mna.api.spells.attributes.Attribute;
 import com.mna.api.spells.parts.Shape;
 import com.mna.api.spells.targeting.SpellSource;
 import com.mna.api.spells.targeting.SpellTarget;
-import com.mna.spells.shapes.ShapeProjectile;
 import com.mna.spells.shapes.ShapeSelf;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.item.ItemStack;
 import org.sosly.arcaneadditions.config.ServerConfig;
-import org.sosly.arcaneadditions.entities.ai.config.FamiliarAIConfig;
 import org.sosly.arcaneadditions.spells.FamiliarSpell;
 import org.sosly.arcaneadditions.spells.shapes.FamiliarShape;
 import org.sosly.arcaneadditions.spells.shapes.SharedShape;
-import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
 import java.util.EnumSet;
 import java.util.Optional;
@@ -55,28 +52,50 @@ public class CastOffensiveSpell extends AbstractFamiliarGoal {
         if (familiar.getTarget() == null) {
             return false;
         }
-        long sinceLastAttempt = familiar.getServer().overworld().getGameTime() - lastAttempt;
+
+        long currentTime = familiar.getServer().overworld().getGameTime();
+        boolean hasAvailableSpell = capability.getSpellsKnown().stream()
+                .filter(FamiliarSpell::isOffensive)
+                .anyMatch(spell -> {
+                    long sinceLastCast = currentTime - spell.getLastCast();
+                    return sinceLastCast >= spell.getFrequency().getSeconds() * 20;
+                });
+
+        if (!hasAvailableSpell) {
+            return false;
+        }
+
+        long sinceLastAttempt = currentTime - lastAttempt;
         if (sinceLastAttempt < ServerConfig.spellCastAttemptCooldown) {
             return false;
         }
-        lastAttempt = familiar.getServer().overworld().getGameTime();
-        spellToCast = capability.getSpellsKnown().stream()
-                .filter(FamiliarSpell::isOffensive)
-                .filter(spell -> {
-                    int sinceLastCast = (int) ((familiar.getServer().overworld().getGameTime() - spell.getLastCast()) / FamiliarAIConfig.TICKS_PER_SECOND);
-                    if (sinceLastCast < (spell.getFrequency().getSeconds() / FamiliarAIConfig.SPELL_FREQUENCY_DIVISOR)) {
-                        return false;
-                    }
-                    int possibility = Math.max(FamiliarHelper.calculateSpellcastingProbability(spell.getFrequency().getSeconds(), sinceLastCast), 1);
-                    int random = familiar.getServer().overworld().getRandom().nextInt(possibility);
-                    return random == 0;
-                })
-                .findAny();
-        return spellToCast.isPresent();
+
+        return hasAvailableSpell;
     }
 
     public boolean canContinueToUse() {
-        return !this.hasCast && !this.cannotCast;
+        if (this.hasCast) {
+            return false;
+        }
+
+        if (!hasValidCapability() || isOrderedToStay()) {
+            return false;
+        }
+
+        if (!spellToCast.isPresent()) {
+            return false;
+        }
+
+        float mana = spellToCast.get().getRecipe().getManaCost();
+        if (capability.getCastingResource().getAmount() < mana + ServerConfig.spellMinimumManaBuffer) {
+            return false;
+        }
+
+        if (target == null || target.isRemoved()) {
+            return false;
+        }
+
+        return true;
     }
 
 
@@ -85,31 +104,47 @@ public class CastOffensiveSpell extends AbstractFamiliarGoal {
     }
 
     @Override
+    public boolean isInterruptable() {
+        return false;
+    }
+
+    @Override
     public void start() {
         super.start();
-
         hasCast = false;
+        lastAttempt = familiar.getServer().overworld().getGameTime();
+
+        selectSpellToCast();
+
+        if (!spellToCast.isPresent()) {
+            this.cannotCast = true;
+            return;
+        }
+
         FamiliarSpell spell = spellToCast.get();
         if (spell.getRecipe().getShape() == null) {
             return;
         }
+
         Shape shape = spell.getRecipe().getShape().getPart();
+
         if (shape instanceof FamiliarShape || shape instanceof SharedShape || shape instanceof ShapeSelf) {
             target = familiar;
             distance = 0;
-        } else if (shape instanceof ShapeProjectile) {
-            if (!hasValidCapability()) {
-                return;
-            }
-            target = familiar.getTarget();
-            distance = maxCastDistance;
-        } else {
-            if (!hasValidCapability()) {
-                return;
-            }
-            target = familiar.getTarget();
-            distance = Math.max(spellToCast.get().getRecipe().getShape().getValue(Attribute.RANGE), FamiliarAIConfig.DEFAULT_MIN_ATTRIBUTE_RANGE);
+            return;
         }
+
+        if (!hasValidCapability()) {
+            return;
+        }
+
+        target = familiar.getTarget();
+
+        distance = switch (shape.getClass().getSimpleName()) {
+            case "ShapeProjectile" -> maxCastDistance;
+            case "ShapeBeam", "ShapeCone" -> Math.min(8.0, maxCastDistance);
+            default -> Math.max(spell.getRecipe().getShape().getValue(Attribute.RANGE), Constants.DEFAULT_MIN_ATTRIBUTE_RANGE);
+        };
     }
 
     @Override
@@ -118,43 +153,74 @@ public class CastOffensiveSpell extends AbstractFamiliarGoal {
         this.hasCast = false;
         this.cannotCast = false;
         this.target = null;
+        this.spellToCast = Optional.empty();
+        this.seeTime = 0;
+        this.strafingTime = -1;
+        this.distance = 0;
     }
 
     @Override
     public void tick() {
-        if (!this.canContinueToUse()) {
-            this.stop();
-            return;
-        }
-
-        if (!hasValidCapability() || isOrderedToStay()) {
-            this.cannotCast = true;
-            return;
-        }
-
-        float mana = spellToCast.get().getRecipe().getManaCost();
-        if (capability.getCastingResource().getAmount() < mana + ServerConfig.spellMinimumManaBuffer) {
-            this.cannotCast = true;
-            return;
-        }
-
-        if (target == null || target.isRemoved()) {
-            this.cannotCast = true;
-            return;
-        }
-
         if (target.equals(familiar)) {
-            familiar.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
-            ManaAndArtificeMod.getSpellHelper()
-                    .affect(spellToCast.get().getRecipe().createAsSpell(), spellToCast.get().getRecipe(),
-                            familiar.level(), new SpellSource(familiar, InteractionHand.MAIN_HAND), new SpellTarget(familiar));
-            this.hasCast = true;
+            castSpellOnSelf();
             return;
         }
 
         double distanceToTarget = familiar.distanceToSqr(target.getX(), target.getY(), target.getZ());
+        updateSeeTime();
+
+        if (shouldStrafe(distanceToTarget)) {
+            familiar.getNavigation().stop();
+            ++this.strafingTime;
+        } else {
+            familiar.getNavigation().moveTo(target, ServerConfig.spellNavigationSpeed);
+            this.strafingTime = -1;
+        }
+
+        updateStrafingBehavior(distanceToTarget);
+
+        if (distanceToTarget > distance) {
+            return;
+        }
+
+        familiar.getNavigation().stop();
+        familiar.getLookControl().setLookAt(target, (float)ServerConfig.spellLookAtSpeed, (float)ServerConfig.spellLookAtSpeed);
+        familiar.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
+
+        ManaAndArtificeMod.getSpellHelper()
+                .affect(spellToCast.get().getRecipe().createAsSpell(), spellToCast.get().getRecipe(),
+                        familiar.level(), new SpellSource(familiar, InteractionHand.MAIN_HAND), new SpellTarget(target));
+
+        float mana = spellToCast.get().getRecipe().getManaCost();
+        capability.getCastingResource().consume(familiar, mana);
+        this.hasCast = true;
+        this.spellToCast.get().setLastCast(familiar.getServer().overworld().getGameTime());
+    }
+
+    private void castSpellOnSelf() {
+        familiar.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
+        ManaAndArtificeMod.getSpellHelper()
+                .affect(spellToCast.get().getRecipe().createAsSpell(), spellToCast.get().getRecipe(),
+                        familiar.level(), new SpellSource(familiar, InteractionHand.MAIN_HAND), new SpellTarget(familiar));
+        this.hasCast = true;
+    }
+
+    private void selectSpellToCast() {
+        long currentTime = familiar.getServer().overworld().getGameTime();
+
+        spellToCast = capability.getSpellsKnown().stream()
+                .filter(FamiliarSpell::isOffensive)
+                .filter(spell -> {
+                    long sinceLastCast = currentTime - spell.getLastCast();
+                    return sinceLastCast >= spell.getFrequency().getSeconds() * 20;
+                })
+                .findAny();
+    }
+
+    private void updateSeeTime() {
         boolean canSee = familiar.getSensing().hasLineOfSight(target);
         boolean positiveSeeTime = this.seeTime > 0;
+
         if (canSee != positiveSeeTime) {
             this.seeTime = 0;
         }
@@ -164,53 +230,57 @@ public class CastOffensiveSpell extends AbstractFamiliarGoal {
         } else {
             --this.seeTime;
         }
+    }
 
-        if (!(distanceToTarget > distance || distanceToTarget > maxCastDistance) && seeTime >= ServerConfig.spellSightRequiredTime) {
-            familiar.getNavigation().stop();
-            ++this.strafingTime;
-        } else {
-            familiar.getNavigation().moveTo(target, ServerConfig.spellNavigationSpeed);
-            this.strafingTime = -1;
-        }
+    private boolean shouldStrafe(double distanceToTarget) {
+        return distanceToTarget <= distance
+            && distanceToTarget <= maxCastDistance
+            && seeTime >= ServerConfig.spellSightRequiredTime;
+    }
 
+    private void updateStrafingBehavior(double distanceToTarget) {
         if (this.strafingTime >= ServerConfig.spellStrafingRecalcTime) {
-            if ((double)familiar.getRandom().nextFloat() < ServerConfig.spellStrafingChance) {
-                strafingClockwise = !strafingClockwise;
-            }
-
-            if ((double)familiar.getRandom().nextFloat() < ServerConfig.spellStrafingChance) {
-                strafingBackwards = !strafingBackwards;
-            }
-
+            recalculateStrafingDirection();
             strafingTime = 0;
         }
 
-        if (strafingTime >= -1) {
-            if (distanceToTarget > distance * ServerConfig.spellStrafingBackwardThreshold) {
-                strafingBackwards = false;
-            } else if (distanceToTarget < distance * ServerConfig.spellStrafingForwardThreshold) {
-                strafingBackwards = true;
-            }
-
-            float forward = strafingBackwards ? FamiliarAIConfig.STRAFE_BACKWARD_SPEED : FamiliarAIConfig.STRAFE_FORWARD_SPEED;
-            float strafe = strafingClockwise ? FamiliarAIConfig.STRAFE_RIGHT_SPEED : FamiliarAIConfig.STRAFE_LEFT_SPEED;
-            familiar.getMoveControl().strafe(forward * (float)ServerConfig.spellStrafingSpeed, strafe * (float)ServerConfig.spellStrafingSpeed);
-            familiar.lookAt(target, (float)ServerConfig.spellLookAtSpeed, (float)ServerConfig.spellLookAtSpeed);
-        } else {
+        if (strafingTime < -1) {
             familiar.getLookControl().setLookAt(target, (float)ServerConfig.spellLookAtSpeed, (float)ServerConfig.spellLookAtSpeed);
+            return;
         }
 
-        if (distanceToTarget <= distance) {
-            familiar.getNavigation().stop();
-            familiar.getLookControl().setLookAt(target, (float)ServerConfig.spellLookAtSpeed, (float)ServerConfig.spellLookAtSpeed);
-            familiar.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
-            ManaAndArtificeMod.getSpellHelper()
-                    .affect(spellToCast.get().getRecipe().createAsSpell(), spellToCast.get().getRecipe(),
-                            familiar.level(), new SpellSource(familiar, InteractionHand.MAIN_HAND), new SpellTarget(target));
-            capability.getCastingResource().consume(familiar, mana);
-            this.hasCast = true;
-            this.spellToCast.get().setLastCast(familiar.getServer().overworld().getGameTime());
-            this.stop();
+        adjustStrafingDistance(distanceToTarget);
+        performStrafing();
+    }
+
+    private void recalculateStrafingDirection() {
+        if (familiar.getRandom().nextFloat() < ServerConfig.spellStrafingChance) {
+            strafingClockwise = !strafingClockwise;
         }
+        if (familiar.getRandom().nextFloat() < ServerConfig.spellStrafingChance) {
+            strafingBackwards = !strafingBackwards;
+        }
+    }
+
+    private void adjustStrafingDistance(double distanceToTarget) {
+        if (distanceToTarget > distance * ServerConfig.spellStrafingBackwardThreshold) {
+            strafingBackwards = false;
+            return;
+        }
+
+        if (distanceToTarget < distance * ServerConfig.spellStrafingForwardThreshold) {
+            strafingBackwards = true;
+        }
+    }
+
+    private void performStrafing() {
+        float forward = strafingBackwards ? Constants.STRAFE_BACKWARD_SPEED : Constants.STRAFE_FORWARD_SPEED;
+        float strafe = strafingClockwise ? Constants.STRAFE_RIGHT_SPEED : Constants.STRAFE_LEFT_SPEED;
+
+        familiar.getMoveControl().strafe(
+            forward * (float)ServerConfig.spellStrafingSpeed,
+            strafe * (float)ServerConfig.spellStrafingSpeed
+        );
+        familiar.lookAt(target, (float)ServerConfig.spellLookAtSpeed, (float)ServerConfig.spellLookAtSpeed);
     }
 }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/CastUtilitySpell.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/CastUtilitySpell.java
@@ -5,24 +5,20 @@ import com.mna.api.spells.attributes.Attribute;
 import com.mna.api.spells.parts.Shape;
 import com.mna.api.spells.targeting.SpellSource;
 import com.mna.api.spells.targeting.SpellTarget;
-import com.mna.spells.shapes.ShapeProjectile;
 import com.mna.spells.shapes.ShapeSelf;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.item.ItemStack;
-import org.sosly.arcaneadditions.capabilities.familiar.IFamiliarCapability;
+import org.sosly.arcaneadditions.config.ServerConfig;
 import org.sosly.arcaneadditions.spells.FamiliarSpell;
 import org.sosly.arcaneadditions.spells.shapes.FamiliarShape;
 import org.sosly.arcaneadditions.spells.shapes.SharedShape;
-import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
 import java.util.EnumSet;
 import java.util.Optional;
 
-public class CastUtilitySpell extends Goal {
-    private final Mob familiar;
+public class CastUtilitySpell extends AbstractFamiliarGoal {
     private final float maxCastDistance;
     private boolean hasCast;
     private boolean cannotCast;
@@ -36,81 +32,114 @@ public class CastUtilitySpell extends Goal {
     private int strafingTime;
 
     public CastUtilitySpell(Mob familiar, float maxCastDistance) {
+        super(familiar);
         this.lastAttempt = -1;
         this.distance = 0;
         this.strafingTime = -1;
         this.hasCast = false;
-        this.familiar = familiar;
         this.maxCastDistance = maxCastDistance;
         this.setFlags(EnumSet.of(Flag.MOVE, Flag.LOOK));
     }
 
     @Override
     public boolean canUse() {
-        IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-        if (cap == null || cap.isOrderedToStay() || cap.isBapped()) {
+        if (!hasValidCapability() || isOrderedToStay() || isBapped()) {
             return false;
         }
-        if (cap.getSpellsKnown().isEmpty()) {
+        if (capability.getSpellsKnown().isEmpty()) {
             return false;
         }
-        long sinceLastAttempt = familiar.getServer().overworld().getGameTime() - lastAttempt;
-        if (sinceLastAttempt < 20L) {
-            return false;
-        }
-        lastAttempt = familiar.getServer().overworld().getGameTime();
-        spellToCast = cap.getSpellsKnown().stream()
+
+        long currentTime = familiar.getServer().overworld().getGameTime();
+        boolean hasAvailableSpell = capability.getSpellsKnown().stream()
                 .filter(spell -> !spell.isOffensive())
-                .filter(spell -> {
-                    int sinceLastCast = (int) ((familiar.getServer().overworld().getGameTime() - spell.getLastCast())/20);
-                    if (sinceLastCast < (spell.getFrequency().getSeconds()/4)) {
-                        return false;
-                    }
-                    int possibility = Math.max(FamiliarHelper.calculateSpellcastingProbability(spell.getFrequency().getSeconds(), sinceLastCast), 1);
-                    int random = familiar.getServer().overworld().getRandom().nextInt(possibility);
-                    return random == 0;
-                })
-                .findAny();
-        return spellToCast.isPresent();
+                .anyMatch(spell -> {
+                    long sinceLastCast = currentTime - spell.getLastCast();
+                    return sinceLastCast >= spell.getFrequency().getSeconds() * 20;
+                });
+
+        if (!hasAvailableSpell) {
+            return false;
+        }
+
+        long sinceLastAttempt = currentTime - lastAttempt;
+        if (sinceLastAttempt < ServerConfig.spellCastAttemptCooldown) {
+            return false;
+        }
+
+        return hasAvailableSpell;
     }
 
     public boolean canContinueToUse() {
-        return !this.hasCast && !this.cannotCast;
-    }
+        if (this.hasCast) {
+            return false;
+        }
 
+        if (!hasValidCapability() || isOrderedToStay()) {
+            return false;
+        }
+
+        if (!spellToCast.isPresent()) {
+            return false;
+        }
+
+        float mana = spellToCast.get().getRecipe().getManaCost();
+        if (capability.getCastingResource().getAmount() < mana + ServerConfig.spellMinimumManaBuffer) {
+            return false;
+        }
+
+        if (target == null || target.isRemoved()) {
+            return false;
+        }
+
+        return true;
+    }
 
     public boolean requiresUpdateEveryTick() {
         return true;
     }
 
     @Override
+    public boolean isInterruptable() {
+        return false;
+    }
+
+    @Override
     public void start() {
         super.start();
-
         hasCast = false;
+        lastAttempt = familiar.getServer().overworld().getGameTime();
+
+        selectSpellToCast();
+
+        if (!spellToCast.isPresent()) {
+            this.cannotCast = true;
+            return;
+        }
+
         FamiliarSpell spell = spellToCast.get();
         if (spell.getRecipe().getShape() == null) {
             return;
         }
+
         Shape shape = spell.getRecipe().getShape().getPart();
+
         if (shape instanceof FamiliarShape || shape instanceof SharedShape || shape instanceof ShapeSelf) {
             target = familiar;
             distance = 0;
-        } else if (shape instanceof ShapeProjectile) {
-            IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-            if (cap == null) {
-                return;
-            }
-            target = cap.getCaster();
-            distance = maxCastDistance;
-        } else {
-            IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-            if (cap == null) {
-                return;
-            }
-            target = cap.getCaster();
-            distance = Math.max(spellToCast.get().getRecipe().getShape().getValue(Attribute.RANGE), 4);
+            return;
         }
+
+        target = getCaster();
+        if (target == null) {
+            return;
+        }
+
+        distance = switch (shape.getClass().getSimpleName()) {
+            case "ShapeProjectile" -> maxCastDistance;
+            case "ShapeBeam", "ShapeCone" -> Math.min(8.0, maxCastDistance);
+            default -> Math.max(spell.getRecipe().getShape().getValue(Attribute.RANGE), Constants.DEFAULT_MIN_ATTRIBUTE_RANGE);
+        };
     }
 
     @Override
@@ -118,44 +147,75 @@ public class CastUtilitySpell extends Goal {
         super.stop();
         this.hasCast = false;
         this.cannotCast = false;
+        this.target = null;
+        this.spellToCast = Optional.empty();
+        this.seeTime = 0;
+        this.strafingTime = -1;
+        this.distance = 0;
     }
 
     @Override
     public void tick() {
-        if (!this.canContinueToUse()) {
-            this.stop();
-            return;
-        }
-
-        IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-        if (cap == null || cap.isOrderedToStay()) {
-            this.cannotCast = true;
-            return;
-        }
-
-        float mana = spellToCast.get().getRecipe().getManaCost();
-        if (cap.getCastingResource().getAmount() < mana + 10) {
-            this.cannotCast = true;
-            return;
-        }
-
-        if (target == null || target.isRemoved()) {
-            this.cannotCast = true;
-            return;
-        }
-
         if (target.equals(familiar)) {
-            familiar.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
-            ManaAndArtificeMod.getSpellHelper()
-                    .affect(spellToCast.get().getRecipe().createAsSpell(), spellToCast.get().getRecipe(),
-                            familiar.level(), new SpellSource(familiar, InteractionHand.MAIN_HAND), new SpellTarget(familiar));
-            this.hasCast = true;
+            castSpellOnSelf();
             return;
         }
 
         double distanceToTarget = familiar.distanceToSqr(target.getX(), target.getY(), target.getZ());
+        updateSeeTime();
+
+        if (shouldStrafe(distanceToTarget)) {
+            familiar.getNavigation().stop();
+            ++this.strafingTime;
+        } else {
+            familiar.getNavigation().moveTo(target, ServerConfig.spellNavigationSpeed);
+            this.strafingTime = -1;
+        }
+
+        updateStrafingBehavior(distanceToTarget);
+
+        if (distanceToTarget > distance) {
+            return;
+        }
+
+        familiar.getNavigation().stop();
+        familiar.getLookControl().setLookAt(target, (float)ServerConfig.spellLookAtSpeed, (float)ServerConfig.spellLookAtSpeed);
+        familiar.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
+
+        ManaAndArtificeMod.getSpellHelper()
+                .affect(spellToCast.get().getRecipe().createAsSpell(), spellToCast.get().getRecipe(),
+                        familiar.level(), new SpellSource(familiar, InteractionHand.MAIN_HAND), new SpellTarget(target));
+
+        float mana = spellToCast.get().getRecipe().getManaCost();
+        capability.getCastingResource().consume(familiar, mana);
+        this.hasCast = true;
+        this.spellToCast.get().setLastCast(familiar.getServer().overworld().getGameTime());
+    }
+
+    private void castSpellOnSelf() {
+        familiar.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
+        ManaAndArtificeMod.getSpellHelper()
+                .affect(spellToCast.get().getRecipe().createAsSpell(), spellToCast.get().getRecipe(),
+                        familiar.level(), new SpellSource(familiar, InteractionHand.MAIN_HAND), new SpellTarget(familiar));
+        this.hasCast = true;
+    }
+
+    private void selectSpellToCast() {
+        long currentTime = familiar.getServer().overworld().getGameTime();
+
+        spellToCast = capability.getSpellsKnown().stream()
+                .filter(spell -> !spell.isOffensive())
+                .filter(spell -> {
+                    long sinceLastCast = currentTime - spell.getLastCast();
+                    return sinceLastCast >= spell.getFrequency().getSeconds() * 20;
+                })
+                .findAny();
+    }
+
+    private void updateSeeTime() {
         boolean canSee = familiar.getSensing().hasLineOfSight(target);
         boolean positiveSeeTime = this.seeTime > 0;
+
         if (canSee != positiveSeeTime) {
             this.seeTime = 0;
         }
@@ -165,51 +225,57 @@ public class CastUtilitySpell extends Goal {
         } else {
             --this.seeTime;
         }
+    }
 
-        if (!(distanceToTarget > distance || distanceToTarget > maxCastDistance) && seeTime >= 20) {
-            familiar.getNavigation().stop();
-            ++this.strafingTime;
-        } else {
-            familiar.getNavigation().moveTo(target, 1.0D);
-            this.strafingTime = -1;
-        }
+    private boolean shouldStrafe(double distanceToTarget) {
+        return distanceToTarget <= distance
+            && distanceToTarget <= maxCastDistance
+            && seeTime >= ServerConfig.spellSightRequiredTime;
+    }
 
-        if (this.strafingTime >= 20) {
-            if ((double)familiar.getRandom().nextFloat() < 0.3D) {
-                strafingClockwise = !strafingClockwise;
-            }
-
-            if ((double)familiar.getRandom().nextFloat() < 0.3D) {
-                strafingBackwards = !strafingBackwards;
-            }
-
+    private void updateStrafingBehavior(double distanceToTarget) {
+        if (this.strafingTime >= ServerConfig.spellStrafingRecalcTime) {
+            recalculateStrafingDirection();
             strafingTime = 0;
         }
 
-        if (strafingTime >= -1) {
-            if (distanceToTarget > distance * 0.75) {
-                strafingBackwards = false;
-            } else if (distanceToTarget < distance * 0.25) {
-                strafingBackwards = true;
-            }
-
-            familiar.getMoveControl().strafe(strafingBackwards ? -0.5F : 0.5F, strafingClockwise ? 0.5F : -0.5F);
-            familiar.lookAt(target, 30.0F, 30.0F);
-        } else {
-            familiar.getLookControl().setLookAt(target, 30.0F, 30.0F);
+        if (strafingTime < -1) {
+            familiar.getLookControl().setLookAt(target, (float)ServerConfig.spellLookAtSpeed, (float)ServerConfig.spellLookAtSpeed);
+            return;
         }
 
-        if (distanceToTarget <= distance) {
-            familiar.getNavigation().stop();
-            familiar.getLookControl().setLookAt(target, 30.0F, 30.0F);
-            familiar.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
-            ManaAndArtificeMod.getSpellHelper()
-                    .affect(spellToCast.get().getRecipe().createAsSpell(), spellToCast.get().getRecipe(),
-                            familiar.level(), new SpellSource(familiar, InteractionHand.MAIN_HAND), new SpellTarget(target));
-            cap.getCastingResource().consume(familiar, mana);
-            this.hasCast = true;
-            this.spellToCast.get().setLastCast(familiar.getServer().overworld().getGameTime());
-            this.stop();
+        adjustStrafingDistance(distanceToTarget);
+        performStrafing();
+    }
+
+    private void recalculateStrafingDirection() {
+        if (familiar.getRandom().nextFloat() < ServerConfig.spellStrafingChance) {
+            strafingClockwise = !strafingClockwise;
         }
+        if (familiar.getRandom().nextFloat() < ServerConfig.spellStrafingChance) {
+            strafingBackwards = !strafingBackwards;
+        }
+    }
+
+    private void adjustStrafingDistance(double distanceToTarget) {
+        if (distanceToTarget > distance * ServerConfig.spellStrafingBackwardThreshold) {
+            strafingBackwards = false;
+            return;
+        }
+
+        if (distanceToTarget < distance * ServerConfig.spellStrafingForwardThreshold) {
+            strafingBackwards = true;
+        }
+    }
+
+    private void performStrafing() {
+        float forward = strafingBackwards ? Constants.STRAFE_BACKWARD_SPEED : Constants.STRAFE_FORWARD_SPEED;
+        float strafe = strafingClockwise ? Constants.STRAFE_RIGHT_SPEED : Constants.STRAFE_LEFT_SPEED;
+
+        familiar.getMoveControl().strafe(
+            forward * (float)ServerConfig.spellStrafingSpeed,
+            strafe * (float)ServerConfig.spellStrafingSpeed
+        );
+        familiar.lookAt(target, (float)ServerConfig.spellLookAtSpeed, (float)ServerConfig.spellLookAtSpeed);
     }
 }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/CasterHurtByTargetGoal.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/CasterHurtByTargetGoal.java
@@ -2,49 +2,44 @@ package org.sosly.arcaneadditions.entities.ai;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
 import net.minecraft.world.entity.player.Player;
-import org.sosly.arcaneadditions.capabilities.familiar.IFamiliarCapability;
-import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
 import java.util.EnumSet;
 
-public class CasterHurtByTargetGoal extends TargetGoal {
-    private final Mob familiar;
+public class CasterHurtByTargetGoal extends AbstractFamiliarTargetGoal {
     private LivingEntity casterLastHurtBy;
     private int timestamp;
 
     public CasterHurtByTargetGoal(Mob familiar) {
         super(familiar, false);
-        this.familiar = familiar;
         this.setFlags(EnumSet.of(Flag.TARGET));
     }
 
     public boolean canUse() {
-        IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-        if (cap == null || cap.isOrderedToStay()) {
+        if (!hasValidCapability() || isOrderedToStay()) {
+            System.out.println("[DEBUG] CasterHurtByTarget: No capability or ordered to stay");
             return false;
         }
 
-        Player caster = cap.getCaster();
+        Player caster = getCaster();
         if (caster == null) {
+            System.out.println("[DEBUG] CasterHurtByTarget: No caster");
             return false;
         }
 
         casterLastHurtBy = caster.getLastHurtByMob();
         int i = caster.getLastHurtByMobTimestamp();
-        return i != timestamp && this.canAttack(casterLastHurtBy, TargetingConditions.DEFAULT);
+        boolean result = i != timestamp && this.canAttack(casterLastHurtBy, TargetingConditions.DEFAULT);
+        if (result && casterLastHurtBy != null) {
+            System.out.println("[DEBUG] CasterHurtByTarget: Setting target to " + casterLastHurtBy.getName().getString());
+        }
+        return result;
     }
 
     public void start() {
-        IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-        if (cap == null) {
-            return;
-        }
-        Player caster = cap.getCaster();
-
-        familiar.setTarget(casterLastHurtBy);
+        mob.setTarget(casterLastHurtBy);
+        Player caster = getCaster();
         if (caster != null) {
             timestamp = caster.getLastHurtByMobTimestamp();
         }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/CasterHurtTargetGoal.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/CasterHurtTargetGoal.java
@@ -2,32 +2,26 @@ package org.sosly.arcaneadditions.entities.ai;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
 import net.minecraft.world.entity.player.Player;
-import org.sosly.arcaneadditions.capabilities.familiar.IFamiliarCapability;
-import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
 import java.util.EnumSet;
 
-public class CasterHurtTargetGoal extends TargetGoal {
-    private final Mob familiar;
+public class CasterHurtTargetGoal extends AbstractFamiliarTargetGoal {
     private LivingEntity casterLastHurt;
     private int timestamp;
 
     public CasterHurtTargetGoal(Mob familiar) {
         super(familiar, false);
-        this.familiar = familiar;
         this.setFlags(EnumSet.of(Flag.TARGET));
     }
 
     public boolean canUse() {
-        IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-        if (cap == null || cap.isOrderedToStay()) {
+        if (!hasValidCapability() || isOrderedToStay()) {
             return false;
         }
 
-        Player caster = cap.getCaster();
+        Player caster = getCaster();
         if (caster == null) {
             return false;
         }
@@ -38,13 +32,8 @@ public class CasterHurtTargetGoal extends TargetGoal {
     }
 
     public void start() {
-        IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-        if (cap == null) {
-            return;
-        }
-
-        familiar.setTarget(casterLastHurt);
-        Player caster = cap.getCaster();
+        mob.setTarget(casterLastHurt);
+        Player caster = getCaster();
         if (caster != null) {
             timestamp = caster.getLastHurtMobTimestamp();
         }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/Constants.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/Constants.java
@@ -1,33 +1,33 @@
-package org.sosly.arcaneadditions.entities.ai.config;
+package org.sosly.arcaneadditions.entities.ai;
 
-public final class FamiliarAIConfig {
-    private FamiliarAIConfig() {
+public final class Constants {
+    private Constants() {
     }
 
     public static final int TICKS_PER_SECOND = 20;
-    public static final int SPELL_FREQUENCY_DIVISOR = 4;
-    
+    public static final float SPELL_FREQUENCY_DIVISOR = 4.0f;
+
     public static final float WATER_PATH_COST_FOLLOWING = 0.0F;
-    
+
     public static final int DEFAULT_MIN_ATTRIBUTE_RANGE = 4;
-    
+
     public static final double BLOCK_CENTER_OFFSET = 0.5;
-    
+
     public static final double MIN_TELEPORT_DISTANCE_FROM_CASTER = 2.0;
-    
+
     public static final float STRAFE_BACKWARD_SPEED = -0.5F;
     public static final float STRAFE_FORWARD_SPEED = 0.5F;
     public static final float STRAFE_LEFT_SPEED = -0.5F;
     public static final float STRAFE_RIGHT_SPEED = 0.5F;
-    
+
     public static final double WANDER_VERTICAL_OFFSET = 0.0D;
     public static final float WANDER_PATH_COST_THRESHOLD = 0.0F;
-    
+
     public static final float CAST_DISTANCE_SQUARED = 256.0F;
-    
+
     public static final int MAGIC_LEVEL_DIVISOR = 5;
-    
+
     public static final long MAINTENANCE_TICK_INTERVAL = 40L;
-    
+
     public static final int TRANSFUSE_EFFICIENCY_DIVISOR = 5;
 }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/FollowCasterGoal.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/FollowCasterGoal.java
@@ -13,7 +13,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
 import org.sosly.arcaneadditions.config.ServerConfig;
-import org.sosly.arcaneadditions.entities.ai.config.FamiliarAIConfig;
 
 import java.util.EnumSet;
 
@@ -75,7 +74,7 @@ public class FollowCasterGoal extends AbstractFamiliarGoal {
         super.start();
         timeToRecalcPath = 0;
         oldWaterCost = familiar.getPathfindingMalus(BlockPathTypes.WATER);
-        familiar.setPathfindingMalus(BlockPathTypes.WATER, FamiliarAIConfig.WATER_PATH_COST_FOLLOWING);
+        familiar.setPathfindingMalus(BlockPathTypes.WATER, Constants.WATER_PATH_COST_FOLLOWING);
     }
 
     public void stop() {
@@ -140,14 +139,14 @@ public class FollowCasterGoal extends AbstractFamiliarGoal {
             return false;
         }
 
-        if (Math.abs((double)x - caster.getX()) < FamiliarAIConfig.MIN_TELEPORT_DISTANCE_FROM_CASTER && Math.abs((double)z - caster.getZ()) < FamiliarAIConfig.MIN_TELEPORT_DISTANCE_FROM_CASTER) {
+        if (Math.abs((double)x - caster.getX()) < Constants.MIN_TELEPORT_DISTANCE_FROM_CASTER && Math.abs((double)z - caster.getZ()) < Constants.MIN_TELEPORT_DISTANCE_FROM_CASTER) {
             return false;
         }
         if (!isTeleportFriendlyBlock(new BlockPos(x, y, z))) {
             return false;
         }
 
-        familiar.moveTo((double)x + FamiliarAIConfig.BLOCK_CENTER_OFFSET, (double)y, (double)z + FamiliarAIConfig.BLOCK_CENTER_OFFSET, familiar.getYRot(), familiar.getXRot());
+        familiar.moveTo((double)x + Constants.BLOCK_CENTER_OFFSET, (double)y, (double)z + Constants.BLOCK_CENTER_OFFSET, familiar.getYRot(), familiar.getXRot());
         navigator.stop();
         return true;
     }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/NeverTargetCasterGoal.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/NeverTargetCasterGoal.java
@@ -2,33 +2,27 @@ package org.sosly.arcaneadditions.entities.ai;
 
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.ai.goal.target.TargetGoal;
 import net.minecraft.world.entity.player.Player;
-import org.sosly.arcaneadditions.capabilities.familiar.IFamiliarCapability;
-import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
-public class NeverTargetCasterGoal extends TargetGoal {
-    private final Mob familiar;
+public class NeverTargetCasterGoal extends AbstractFamiliarTargetGoal {
     protected LivingEntity target;
 
     public NeverTargetCasterGoal(Mob familiar) {
         super(familiar, false);
-        this.familiar = familiar;
     }
 
     @Override
     public boolean canUse() {
-        IFamiliarCapability cap = FamiliarHelper.getFamiliarCapability(familiar);
-        if (cap == null || cap.isOrderedToStay()) {
+        if (!hasValidCapability() || isOrderedToStay()) {
             return false;
         }
 
-        Player caster = cap.getCaster();
-        return caster != null && caster.is(familiar.getTarget());
+        Player caster = getCaster();
+        return caster != null && caster.is(mob.getTarget());
     }
 
     public void start() {
-        familiar.setTarget(null);
+        mob.setTarget(null);
         super.start();
     }
 }

--- a/src/main/java/org/sosly/arcaneadditions/entities/ai/RandomWanderGoal.java
+++ b/src/main/java/org/sosly/arcaneadditions/entities/ai/RandomWanderGoal.java
@@ -4,18 +4,15 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.control.FlyingMoveControl;
-import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.ai.util.RandomPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
-import org.sosly.arcaneadditions.utils.FamiliarHelper;
 
 import java.util.EnumSet;
 
-public class RandomWanderGoal extends Goal {
-    private final Mob familiar;
+public class RandomWanderGoal extends AbstractFamiliarGoal {
     private final double speed;
     private final int interval;
 
@@ -24,11 +21,11 @@ public class RandomWanderGoal extends Goal {
     private double wantedZ;
 
     public RandomWanderGoal(Mob familiar, double speed, int interval) {
-        this.familiar = familiar;
+        super(familiar);
         this.speed = speed;
         this.interval = interval;
 
-        this.setFlags(EnumSet.of(Goal.Flag.MOVE));
+        this.setFlags(EnumSet.of(Flag.MOVE));
     }
 
     @Override
@@ -96,7 +93,7 @@ public class RandomWanderGoal extends Goal {
     @Nullable
     private BlockPos getWanderTarget(int radius, int verticalDistance) {
         BlockPos goal = RandomPos.generateRandomDirection(familiar.getRandom(), radius, verticalDistance);
-        Player caster = FamiliarHelper.getCaster(familiar);
+        Player caster = getCaster();
         BlockPos casterPos = caster != null ? caster.blockPosition() : null;
         int goalX = goal.getX();
         int goalZ = goal.getZ();

--- a/src/main/java/org/sosly/arcaneadditions/spells/components/TransfuseComponent.java
+++ b/src/main/java/org/sosly/arcaneadditions/spells/components/TransfuseComponent.java
@@ -25,7 +25,7 @@ import com.mna.factions.Factions;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.LivingEntity;
-import org.sosly.arcaneadditions.entities.ai.config.FamiliarAIConfig;
+import org.sosly.arcaneadditions.entities.ai.Constants;
 
 public class TransfuseComponent extends SpellEffect implements IDamageComponent {
     public TransfuseComponent(ResourceLocation guiIcon) {
@@ -40,7 +40,7 @@ public class TransfuseComponent extends SpellEffect implements IDamageComponent 
         LivingEntity livingSource = null;
         float damage = mods.getValue(Attribute.DAMAGE) * GeneralConfig.getDamageMultiplier();
         float magnitude = mods.getValue(Attribute.MAGNITUDE);
-        float healing = damage * (magnitude / FamiliarAIConfig.TRANSFUSE_EFFICIENCY_DIVISOR);
+        float healing = damage * (magnitude / Constants.TRANSFUSE_EFFICIENCY_DIVISOR);
 
         if (target.isLivingEntity() && target.getLivingEntity() != null) {
             livingTarget = target.getLivingEntity();

--- a/src/main/java/org/sosly/arcaneadditions/utils/FamiliarHelper.java
+++ b/src/main/java/org/sosly/arcaneadditions/utils/FamiliarHelper.java
@@ -14,7 +14,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import org.sosly.arcaneadditions.capabilities.familiar.FamiliarProvider;
 import org.sosly.arcaneadditions.capabilities.familiar.IFamiliarCapability;
 import org.sosly.arcaneadditions.entities.ai.*;
-import org.sosly.arcaneadditions.entities.ai.config.FamiliarAIConfig;
+import org.sosly.arcaneadditions.entities.ai.Constants;
 
 public class FamiliarHelper {
     private static final String CASTER = "arcaneadditions:familiar/caster";
@@ -51,7 +51,7 @@ public class FamiliarHelper {
         cap.setFamiliar(familiar);
         cap.setType(type);
         cap.setName(name.getString());
-        cap.getCastingResource().setMaxAmountByLevel(magic.getMagicLevel() / FamiliarAIConfig.MAGIC_LEVEL_DIVISOR);
+        cap.getCastingResource().setMaxAmountByLevel(magic.getMagicLevel() / Constants.MAGIC_LEVEL_DIVISOR);
         if (cap.getCastingResource().getMaxAmount() < cap.getCastingResource().getAmount()) {
             cap.getCastingResource().setAmount(cap.getCastingResource().getMaxAmount());
         }
@@ -162,9 +162,9 @@ public class FamiliarHelper {
 
         // Add new goals
         familiar.goalSelector.addGoal(2, new StayWhenOrderedToGoal(familiar));
-        familiar.goalSelector.addGoal(5, new CastOffensiveSpell(familiar, FamiliarAIConfig.CAST_DISTANCE_SQUARED));
+        familiar.goalSelector.addGoal(5, new CastOffensiveSpell(familiar, Constants.CAST_DISTANCE_SQUARED));
         familiar.goalSelector.addGoal(6, new FollowCasterGoal(familiar, 1.0D, 20, 2.0F, 16, false));
-        familiar.goalSelector.addGoal(7, new CastUtilitySpell(familiar, FamiliarAIConfig.CAST_DISTANCE_SQUARED));
+        familiar.goalSelector.addGoal(7, new CastUtilitySpell(familiar, Constants.CAST_DISTANCE_SQUARED));
         familiar.goalSelector.addGoal(10, new RandomWanderGoal(familiar, 1.0D, 20));
 
         familiar.targetSelector.addGoal(0, new NeverTargetCasterGoal(familiar));


### PR DESCRIPTION
# Fix AI goal consistency for familiar spellcasting
Refactors CastUtilitySpell to match improvements made to CastOffensiveSpell, ensuring consistent behavior patterns across all familiar spellcasting AI goals.

## Changes
- Refactored CastUtilitySpell to use the same patterns as CastOffensiveSpell
- Both spell casting AI goals now use consistent spell selection and validation logic
- Replaced remaining hardcoded values with ServerConfig settings and Constants
- Improved familiar spellcasting reliability by fixing cooldown and mana buffer checks
- Fixed familiars attempting to cast spells they couldn't afford or were still on cooldown
- Fixed familiars continuing to try casting spells after their target was defeated
- Added AbstractFamiliarTargetGoal base class for goals that target entities
- Consolidated magic numbers into Constants class (renamed from FamiliarAIConfig)

## Related Issues
Closes #126

## Implementation Notes
The refactoring ensures that both offensive and utility spell casting follow identical patterns for:
- Spell availability checking (cooldown and mana validation)
- Target validation and distance calculations
- Strafe behavior and movement patterns
- Cleanup when goals stop or are interrupted

This eliminates inconsistencies that could cause familiars to behave unpredictably when switching between different types of spells.

## Breaking Changes
None

🤖 Generated with [Claude Code](https://claude.ai/code)