### PR TITLE
Fix loot chest content voiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed familiars attempting to cast spells they couldn't afford or were still on cooldown
 - Fixed familiars continuing to try casting spells after their target was defeated
 - Fixed entity-capability synchronization issues causing familiars to duplicate or become unresponsive during dimension travel
+- Fixed loot chest content voiding caused by familiar shapes being incorrectly included in random spell generation
 
 ## [1.20.1-forge-1.9.6](https://github.com/SoSly/ArcaneAdditions/releases/tag/1.20.1-forge-1.9.6)
 ### Changed

--- a/src/main/java/org/sosly/arcaneadditions/spells/shapes/FamiliarShape.java
+++ b/src/main/java/org/sosly/arcaneadditions/spells/shapes/FamiliarShape.java
@@ -58,4 +58,9 @@ public class FamiliarShape extends Shape {
     public boolean affectsCaster() {
         return false;
     }
+
+    @Override
+    public boolean canBeOnRandomStaff() {
+        return false;
+    }
 }

--- a/src/main/java/org/sosly/arcaneadditions/spells/shapes/SharedShape.java
+++ b/src/main/java/org/sosly/arcaneadditions/spells/shapes/SharedShape.java
@@ -56,4 +56,9 @@ public class SharedShape extends Shape {
     public boolean affectsCaster() {
         return true;
     }
+
+    @Override
+    public boolean canBeOnRandomStaff() {
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary
- Prevents familiar shapes from being included in random spell staff generation
- Fixes NPE that caused loot chests to void their contents

## Changes
- Override `canBeOnRandomStaff()` to return false in FamiliarShape and SharedShape
- These shapes require player/familiar context that doesn't exist during loot generation

## Related Issues
Closes #107

## Test Plan
- [x] Open loot chests with both MNA and Arcane Additions installed
- [x] Verify no NPE in logs
- [x] Confirm chest contents are preserved
- [x] Test that familiar/shared shapes still work in player-crafted spells

🤖 Generated with [Claude Code](https://claude.ai/code)