### PR TITLE
feat: implement configurable plow transformations via recipe system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added familiar AI behavior settings to the server config
 
 ### Changed
+- Plow spell transformations are now data-driven through recipe JSONs, allowing datapack customization and mod compatibility
 - Improved familiar spellcasting reliability; familiars will now more consistently cast offensive and utility spells when appropriate
 - Familiars now better respect their spell cooldowns when deciding whether to cast
 

--- a/src/main/java/org/sosly/arcaneadditions/ArcaneAdditions.java
+++ b/src/main/java/org/sosly/arcaneadditions/ArcaneAdditions.java
@@ -28,6 +28,7 @@ import org.sosly.arcaneadditions.effects.EffectRegistry;
 import org.sosly.arcaneadditions.entities.EntityRegistry;
 import org.sosly.arcaneadditions.gui.MenuRegistry;
 import org.sosly.arcaneadditions.items.ItemRegistry;
+import org.sosly.arcaneadditions.recipes.RecipeRegistry;
 import org.sosly.arcaneadditions.utils.ClientProxy;
 import org.sosly.arcaneadditions.utils.ISidedProxy;
 import org.sosly.arcaneadditions.utils.RLoc;
@@ -52,6 +53,7 @@ public class ArcaneAdditions {
         TileEntityRegistry.TILE_ENTITIES.register(modbus);
         ItemRegistry.ITEMS.register(modbus);
         MenuRegistry.MENUS.register(modbus);
+        RecipeRegistry.register(modbus);
         MinecraftForge.EVENT_BUS.register(this);
         modbus.addListener(ArcaneAdditions::setupCommon);
 

--- a/src/main/java/org/sosly/arcaneadditions/recipes/PlowTransformationRecipe.java
+++ b/src/main/java/org/sosly/arcaneadditions/recipes/PlowTransformationRecipe.java
@@ -1,0 +1,88 @@
+/*
+ *   Arcane Additions Copyright (c)  2022, Kevin Kragenbrink <kevin@writh.net>
+ *           This program comes with ABSOLUTELY NO WARRANTY; for details see <https://www.gnu.org/licenses/gpl-3.0.html>.
+ *           This is free software, and you are welcome to redistribute it under certain
+ *           conditions; detailed at https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.sosly.arcaneadditions.recipes;
+
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.List;
+
+public class PlowTransformationRecipe implements Recipe<Container> {
+    private final ResourceLocation id;
+    final Block input;
+    final BlockState output;
+    final List<ItemStack> drops;
+    final boolean needsAir;
+
+    public PlowTransformationRecipe(ResourceLocation id, Block input, BlockState output, List<ItemStack> drops, boolean needsAir) {
+        this.id = id;
+        this.input = input;
+        this.output = output;
+        this.drops = drops;
+        this.needsAir = needsAir;
+    }
+
+    public boolean matches(BlockState state) {
+        return state.getBlock() == input;
+    }
+
+    public BlockState getOutput() {
+        return output;
+    }
+
+    public List<ItemStack> getDrops() {
+        return drops;
+    }
+
+    public boolean needsAir() {
+        return needsAir;
+    }
+
+    @Override
+    public boolean matches(Container container, Level level) {
+        return false;
+    }
+
+    @Override
+    public ItemStack assemble(Container container, RegistryAccess registryAccess) {
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int width, int height) {
+        return false;
+    }
+
+    @Override
+    public ItemStack getResultItem(RegistryAccess registryAccess) {
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return id;
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return RecipeRegistry.PLOW_TRANSFORMATION_SERIALIZER.get();
+    }
+
+    @Override
+    public RecipeType<?> getType() {
+        return RecipeRegistry.PLOW_TRANSFORMATION_TYPE.get();
+    }
+}

--- a/src/main/java/org/sosly/arcaneadditions/recipes/PlowTransformationSerializer.java
+++ b/src/main/java/org/sosly/arcaneadditions/recipes/PlowTransformationSerializer.java
@@ -1,0 +1,93 @@
+/*
+ *   Arcane Additions Copyright (c)  2022, Kevin Kragenbrink <kevin@writh.net>
+ *           This program comes with ABSOLUTELY NO WARRANTY; for details see <https://www.gnu.org/licenses/gpl-3.0.html>.
+ *           This is free software, and you are welcome to redistribute it under certain
+ *           conditions; detailed at https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.sosly.arcaneadditions.recipes;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PlowTransformationSerializer implements RecipeSerializer<PlowTransformationRecipe> {
+    @Override
+    public PlowTransformationRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
+        String inputId = GsonHelper.getAsString(json, "input");
+        Block input = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(inputId));
+        if (input == null) {
+            throw new IllegalArgumentException("Unknown block: " + inputId);
+        }
+
+        String outputId = GsonHelper.getAsString(json, "output");
+        Block outputBlock = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(outputId));
+        if (outputBlock == null) {
+            throw new IllegalArgumentException("Unknown block: " + outputId);
+        }
+        BlockState output = outputBlock.defaultBlockState();
+
+        List<ItemStack> drops = new ArrayList<>();
+        if (json.has("drops")) {
+            for (JsonElement element : GsonHelper.getAsJsonArray(json, "drops")) {
+                JsonObject dropJson = element.getAsJsonObject();
+                String itemId = GsonHelper.getAsString(dropJson, "item");
+                int count = GsonHelper.getAsInt(dropJson, "count", 1);
+                
+                var item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemId));
+                if (item == null) {
+                    throw new IllegalArgumentException("Unknown item: " + itemId);
+                }
+                
+                drops.add(new ItemStack(item, count));
+            }
+        }
+
+        boolean needsAir = GsonHelper.getAsBoolean(json, "needs_air", true);
+
+        return new PlowTransformationRecipe(recipeId, input, output, drops, needsAir);
+    }
+
+    @Override
+    public PlowTransformationRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer) {
+        ResourceLocation inputId = buffer.readResourceLocation();
+        Block input = ForgeRegistries.BLOCKS.getValue(inputId);
+        
+        ResourceLocation outputId = buffer.readResourceLocation();
+        Block outputBlock = ForgeRegistries.BLOCKS.getValue(outputId);
+        BlockState output = outputBlock != null ? outputBlock.defaultBlockState() : null;
+        
+        int dropCount = buffer.readVarInt();
+        List<ItemStack> drops = new ArrayList<>();
+        for (int i = 0; i < dropCount; i++) {
+            drops.add(buffer.readItem());
+        }
+        
+        boolean needsAir = buffer.readBoolean();
+        
+        return new PlowTransformationRecipe(recipeId, input, output, drops, needsAir);
+    }
+
+    @Override
+    public void toNetwork(FriendlyByteBuf buffer, PlowTransformationRecipe recipe) {
+        buffer.writeResourceLocation(ForgeRegistries.BLOCKS.getKey(recipe.input));
+        buffer.writeResourceLocation(ForgeRegistries.BLOCKS.getKey(recipe.output.getBlock()));
+        
+        buffer.writeVarInt(recipe.drops.size());
+        for (ItemStack drop : recipe.drops) {
+            buffer.writeItem(drop);
+        }
+        
+        buffer.writeBoolean(recipe.needsAir);
+    }
+}

--- a/src/main/java/org/sosly/arcaneadditions/recipes/RecipeRegistry.java
+++ b/src/main/java/org/sosly/arcaneadditions/recipes/RecipeRegistry.java
@@ -1,0 +1,37 @@
+/*
+ *   Arcane Additions Copyright (c)  2022, Kevin Kragenbrink <kevin@writh.net>
+ *           This program comes with ABSOLUTELY NO WARRANTY; for details see <https://www.gnu.org/licenses/gpl-3.0.html>.
+ *           This is free software, and you are welcome to redistribute it under certain
+ *           conditions; detailed at https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+package org.sosly.arcaneadditions.recipes;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+import org.sosly.arcaneadditions.ArcaneAdditions;
+
+public class RecipeRegistry {
+    private static final DeferredRegister<RecipeSerializer<?>> SERIALIZERS = 
+        DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, ArcaneAdditions.MOD_ID);
+    
+    private static final DeferredRegister<RecipeType<?>> TYPES = 
+        DeferredRegister.create(ForgeRegistries.RECIPE_TYPES, ArcaneAdditions.MOD_ID);
+
+    public static final RegistryObject<RecipeType<PlowTransformationRecipe>> PLOW_TRANSFORMATION_TYPE = 
+        TYPES.register("plow_transformation", 
+            () -> RecipeType.simple(new ResourceLocation(ArcaneAdditions.MOD_ID, "plow_transformation")));
+
+    public static final RegistryObject<RecipeSerializer<PlowTransformationRecipe>> PLOW_TRANSFORMATION_SERIALIZER = 
+        SERIALIZERS.register("plow_transformation", PlowTransformationSerializer::new);
+
+    public static void register(IEventBus eventBus) {
+        TYPES.register(eventBus);
+        SERIALIZERS.register(eventBus);
+    }
+}

--- a/src/main/java/org/sosly/arcaneadditions/spells/components/PlowComponent.java
+++ b/src/main/java/org/sosly/arcaneadditions/spells/components/PlowComponent.java
@@ -6,9 +6,6 @@
  */
 
 package org.sosly.arcaneadditions.spells.components;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.mna.api.affinity.Affinity;
 import com.mna.api.sound.SFX;
 import com.mna.api.spells.ComponentApplicationResult;
@@ -18,22 +15,20 @@ import com.mna.api.spells.parts.SpellEffect;
 import com.mna.api.spells.targeting.SpellContext;
 import com.mna.api.spells.targeting.SpellSource;
 import com.mna.api.spells.targeting.SpellTarget;
-import com.mojang.datafixers.util.Pair;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.server.level.ServerLevel;
+import org.sosly.arcaneadditions.recipes.PlowTransformationRecipe;
+import org.sosly.arcaneadditions.recipes.RecipeRegistry;
 
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
+import java.util.List;
 
 public class PlowComponent extends SpellEffect {
     public PlowComponent(ResourceLocation guiIcon) {
@@ -42,28 +37,58 @@ public class PlowComponent extends SpellEffect {
 
     @Override
     public ComponentApplicationResult ApplyEffect(SpellSource caster, SpellTarget target, IModifiedSpellPart<SpellEffect> mods, SpellContext context) {
-        if (target.isBlock()) {
-            Level level = context.getLevel();
-            BlockPos block = target.getBlock();
-            BlockState state = level.getBlockState(target.getBlock());
-
-            if (!context.getLevel().isEmptyBlock(target.getBlock()) && context.getLevel().getFluidState(target.getBlock()).isEmpty() && !(state.getBlock() instanceof EntityBlock)) {
-                Pair<Predicate<SpellBlockContext>, Consumer<SpellBlockContext>> pair = TILLABLES.get(state.getBlock());
-                if (pair != null) {
-                    Predicate<SpellBlockContext> predicate = pair.getFirst();
-                    Consumer<SpellBlockContext> consumer = pair.getSecond();
-                    SpellBlockContext sbx = new SpellBlockContext(level, block);
-
-                    if (predicate.test(sbx)) {
-                        if (!level.isClientSide) {
-                            consumer.accept(sbx);
-                        }
-                    }
-                }
-            }
+        if (!target.isBlock()) {
+            return ComponentApplicationResult.FAIL;
         }
 
-        return ComponentApplicationResult.FAIL;
+        Level level = context.getLevel();
+        BlockPos blockPos = target.getBlock();
+        BlockState state = level.getBlockState(blockPos);
+        
+        if (level.isEmptyBlock(blockPos)) {
+            return ComponentApplicationResult.FAIL;
+        }
+        
+        if (!level.getFluidState(blockPos).isEmpty()) {
+            return ComponentApplicationResult.FAIL;
+        }
+        
+        if (state.getBlock() instanceof EntityBlock) {
+            return ComponentApplicationResult.FAIL;
+        }
+
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return ComponentApplicationResult.SUCCESS;
+        }
+
+        PlowTransformationRecipe recipe = findRecipe(serverLevel, state);
+        if (recipe == null) {
+            return ComponentApplicationResult.FAIL;
+        }
+        
+        if (recipe.needsAir() && !level.isEmptyBlock(blockPos.above())) {
+            return ComponentApplicationResult.FAIL;
+        }
+
+        level.setBlock(blockPos, recipe.getOutput(), 11);
+        
+        for (ItemStack drop : recipe.getDrops()) {
+            Block.popResource(level, blockPos, drop.copy());
+        }
+        
+        return ComponentApplicationResult.SUCCESS;
+    }
+
+    private PlowTransformationRecipe findRecipe(ServerLevel level, BlockState state) {
+        RecipeManager recipeManager = level.getRecipeManager();
+        List<PlowTransformationRecipe> recipes = recipeManager.getAllRecipesFor(RecipeRegistry.PLOW_TRANSFORMATION_TYPE.get());
+        
+        for (PlowTransformationRecipe recipe : recipes) {
+            if (recipe.matches(state)) {
+                return recipe;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -91,47 +116,4 @@ public class PlowComponent extends SpellEffect {
         return SFX.Spell.Cast.WATER;
     }
 
-    // todo: Hoe items are broken in Forge, and the behavior to check for it is incredibly hard to replicate.
-    //       Therefore, this hacky solution is in use for now, but it should be improved if Hoe items are ever fixed.
-    private static final Map<Block, Pair<Predicate<SpellBlockContext>, Consumer<SpellBlockContext>>> TILLABLES = Maps.newHashMap(
-            ImmutableMap.of(
-                    Blocks.GRASS_BLOCK, Pair.of(PlowComponent::onlyIfAirAbove, changeIntoState(Blocks.FARMLAND.defaultBlockState())),
-                    Blocks.DIRT_PATH, Pair.of(PlowComponent::onlyIfAirAbove, changeIntoState(Blocks.FARMLAND.defaultBlockState())),
-                    Blocks.DIRT, Pair.of(PlowComponent::onlyIfAirAbove, changeIntoState(Blocks.FARMLAND.defaultBlockState())),
-                    Blocks.COARSE_DIRT, Pair.of(PlowComponent::onlyIfAirAbove, changeIntoState(Blocks.DIRT.defaultBlockState())),
-                    Blocks.ROOTED_DIRT, Pair.of((context) -> true, changeIntoStateAndDropItem(Blocks.DIRT.defaultBlockState(), Items.HANGING_ROOTS))
-            )
-    );
-
-    public static boolean onlyIfAirAbove(SpellBlockContext context) {
-        return context.getLevel().isEmptyBlock(context.getBlock().above());
-    }
-
-    public static Consumer<SpellBlockContext> changeIntoState(BlockState state) {
-        return (context) -> {
-            context.getLevel().setBlock(context.getBlock(), state, 11);
-        };
-    }
-
-    public static Consumer<SpellBlockContext> changeIntoStateAndDropItem(BlockState state, ItemLike itemToDrop) {
-        return (context) -> {
-            context.getLevel().setBlock(context.getBlock(), state, 11);
-            Block.popResource(context.getLevel(), context.getBlock(), new ItemStack(itemToDrop));
-        };
-    }
-
-    private static class SpellBlockContext {
-        Level level;
-        BlockPos block;
-
-        SpellBlockContext(Level level, BlockPos block) {
-            this.level = level;
-            this.block = block;
-        }
-
-        public BlockPos getBlock() { return this.block; }
-        public Level getLevel() {
-            return this.level;
-        }
-    }
 }

--- a/src/main/resources/data/arcaneadditions/recipes/plow_transformations/coarse_dirt_to_dirt.json
+++ b/src/main/resources/data/arcaneadditions/recipes/plow_transformations/coarse_dirt_to_dirt.json
@@ -1,0 +1,6 @@
+{
+  "type": "arcaneadditions:plow_transformation",
+  "input": "minecraft:coarse_dirt",
+  "output": "minecraft:dirt",
+  "needs_air": true
+}

--- a/src/main/resources/data/arcaneadditions/recipes/plow_transformations/dirt_path_to_farmland.json
+++ b/src/main/resources/data/arcaneadditions/recipes/plow_transformations/dirt_path_to_farmland.json
@@ -1,0 +1,6 @@
+{
+  "type": "arcaneadditions:plow_transformation",
+  "input": "minecraft:dirt_path",
+  "output": "minecraft:farmland",
+  "needs_air": true
+}

--- a/src/main/resources/data/arcaneadditions/recipes/plow_transformations/dirt_to_farmland.json
+++ b/src/main/resources/data/arcaneadditions/recipes/plow_transformations/dirt_to_farmland.json
@@ -1,0 +1,6 @@
+{
+  "type": "arcaneadditions:plow_transformation",
+  "input": "minecraft:dirt",
+  "output": "minecraft:farmland",
+  "needs_air": true
+}

--- a/src/main/resources/data/arcaneadditions/recipes/plow_transformations/grass_to_farmland.json
+++ b/src/main/resources/data/arcaneadditions/recipes/plow_transformations/grass_to_farmland.json
@@ -1,0 +1,6 @@
+{
+  "type": "arcaneadditions:plow_transformation",
+  "input": "minecraft:grass_block",
+  "output": "minecraft:farmland",
+  "needs_air": true
+}

--- a/src/main/resources/data/arcaneadditions/recipes/plow_transformations/rooted_dirt_to_dirt.json
+++ b/src/main/resources/data/arcaneadditions/recipes/plow_transformations/rooted_dirt_to_dirt.json
@@ -1,0 +1,12 @@
+{
+  "type": "arcaneadditions:plow_transformation",
+  "input": "minecraft:rooted_dirt",
+  "output": "minecraft:dirt",
+  "drops": [
+    {
+      "item": "minecraft:hanging_roots",
+      "count": 1
+    }
+  ],
+  "needs_air": false
+}


### PR DESCRIPTION
## Summary
- Replaced hardcoded plow block mappings with data-driven recipe JSON system
- Users can now customize plow transformations through datapacks
- Enables mod compatibility without string parsing configuration

## Implementation
- Created `PlowTransformationRecipe` and serializer for JSON-based transformations
- Registered new recipe type `arcaneadditions:plow_transformation`
- Updated PlowComponent to use RecipeManager instead of ServerConfig
- Added default transformation recipes matching original behavior

## Test Plan
- [ ] Verify grass blocks transform to farmland
- [ ] Verify dirt and dirt paths transform to farmland
- [ ] Verify coarse dirt transforms to regular dirt
- [ ] Verify rooted dirt transforms to dirt and drops hanging roots
- [ ] Test custom datapack with Farmer's Delight rich soil transformation
- [ ] Verify `/reload` properly updates transformations

Closes #127

🤖 Generated with [Claude Code](https://claude.ai/code)