### PR TITLE
Release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/SoSly/ArcaneAdditions/tree/1.20.1)
+## [1.20.1-forge-1.10.0](https://github.com/SoSly/ArcaneAdditions/releases/tag/1.20.1-forge-1.10.0)
 
 ### Added
 - Added familiar AI behavior settings to the server config

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.daemon=false
 ####################
 ## Mod Information
 ####################
-mod_version = 1.9.6
+mod_version = 1.10.0
 mod_authors = nivthefox
 mod_group = org.sosly.arcaneadditions
 mod_id = arcaneadditions


### PR DESCRIPTION
# Release v1.10.0
Finalizes version 1.10.0 for release with familiar AI improvements and dependency updates.

## Summary
- Updates version number from 1.9.6 to 1.10.0 in gradle.properties
- Finalizes CHANGELOG.md for 1.10.0 release (removes "Unreleased" section)

## Test plan
- [ ] Build completes successfully
- [ ] Version appears correctly in mod metadata
- [ ] All features from CHANGELOG work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)